### PR TITLE
added ability to read & write non URI encoded values (because many existing cookies rely on this)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Provides a utility for getting or setting the value of cookies.  Also contains a
 	* `path`: The path where the cookie is valid *default: '/'*
 	* `domain`: The domain where the cookie is valid *default: '.ft.com'*
 	* `secure`: If `true` the cookie will only be sent over https *default: false*
+    * `raw`: If set to `true` gets/sets a cookie's value without sanitising it with `encode/decodeURIComponent()`
 * `remove(name)` - unsets the value of a cookie
 * `getParam(name, param)` - gets the value stored in the given parameter within cookie `name` (only works for some FT cookies which use a predefined syntax for separating parameters)
 * `setParam(name, param, value)` - sets the value stored in the given parameter within cookie `name` (only works for the AYSC FT cookie)

--- a/cookie.js
+++ b/cookie.js
@@ -1,5 +1,14 @@
 var pluses = /\+/g;
 
+
+function encode(s, raw) {
+	return raw ? s : encodeURIComponent(s);
+}
+
+function decode(s, raw) {
+	return raw ? s : decodeURIComponent(s);
+}
+
 function cookie (key, value, options) {
 
 	// Write
@@ -13,7 +22,7 @@ function cookie (key, value, options) {
 		}
 
 		return (document.cookie = [
-			encodeURIComponent(key), '=', encodeURIComponent(String(value)),
+			encodeURIComponent(key), '=', encode(String(value), options.raw),
 			options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
 			options.path    ? '; path=' + options.path : '',
 			options.domain  ? '; domain=' + options.domain : '',
@@ -42,7 +51,7 @@ function cookie (key, value, options) {
 		}
 	}
 
-	return result;
+	return decode(result);
 };
 
 cookie.remove = function (name) {


### PR DESCRIPTION
Please review @triblondon 

Technically it's a breaking change because now the default is to return URI decoded values, although arguably it's a bugfix as previously all values were encoded on write but not decoded on read. Let me know what you think about major vs patch version.
